### PR TITLE
ci(restyled): update restyled config

### DIFF
--- a/.github/restyled.yml
+++ b/.github/restyled.yml
@@ -1,0 +1,2 @@
+auto: true
+commit_template: "style: restyle by ${restyler.name}"

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,9 +1,0 @@
-commit_template: |
-  style: reformat by ${restyler.name}
-
-restylers:
-  - clang-format:
-      enabled: false
-  - prettier-markdown:
-      arguments: ["--prose-wrap", "preserve"]
-  - "*"


### PR DESCRIPTION
- Move the config file to `.github/`.
- Push the restyled commits directly to the original PR.
- Update the commit messages used when Restyler makes fixes.
- Remove prettier-markdown config because it's default now.